### PR TITLE
Build for WIN64

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # Parallel Tasking Library (PTL)
-Lightweight C++11 mutilthreading tasking system featuring thread-pool, task-groups, and lock-free task queue
+Lightweight C++11 multithreading tasking system featuring thread-pool, task-groups, and lock-free task queue

--- a/examples/gpu/sum.h
+++ b/examples/gpu/sum.h
@@ -46,7 +46,7 @@
 #endif
 
 #ifndef DLL
-#    ifdef WIN32
+#    if defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #        define DLL __declspec(dllexport)
 #    else
 #        define DLL

--- a/source/PTL/ThreadLocalStatic.hh
+++ b/source/PTL/ThreadLocalStatic.hh
@@ -50,7 +50,7 @@
 #    define ThreadLocalStatic static thread_local
 #    define ThreadLocal thread_local
 
-#elif defined(WIN32)
+#elif defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #    define ThreadLocalStatic static thread_local
 #    define ThreadLocal thread_local
 

--- a/source/PTL/Timer.hh
+++ b/source/PTL/Timer.hh
@@ -67,7 +67,7 @@
 
 #pragma once
 
-#ifndef WIN32
+#if !(defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64))
 #    include <sys/times.h>
 #    include <unistd.h>
 #else

--- a/source/PTL/Types.hh
+++ b/source/PTL/Types.hh
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 // Disable warning C4786 on WIN32 architectures:
 // identifier was truncated to '255' characters
 // in the debug information

--- a/source/Threading.cc
+++ b/source/Threading.cc
@@ -29,7 +29,7 @@
 #include "PTL/AutoLock.hh"
 #include "PTL/Globals.hh"
 
-#if defined(WIN32)
+#if defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #    include <Windows.h>
 #else
 #    include <sys/syscall.h>

--- a/source/Timer.cc
+++ b/source/Timer.cc
@@ -33,7 +33,7 @@
 #    endif
 #endif
 
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64)
 #    include <sys/types.h>
 #    include <windows.h>
 


### PR DESCRIPTION
This pull request fixes one of the build errors I found when building on Windows 10 x64. The problem was that the WIN32 Macro was not defined because I have a WIN64 system.

However, after fixing this, I am still unable to compile PTL on Windows using MinGW 5.3. There is still a problem linking PTL with the tbb library (from conda tbb-devel). I followed [these directions](http://www.mingw.org/wiki/Specify_the_libraries_for_the_linker_to_use), but I am still getting a bunch of `undefined reference to tbb::foo` errors during linking. Any hints about what might be wrong?