### PR TITLE
Threading: Fix GetNumberOfPhysicalCpus, it should never return zero

### DIFF
--- a/source/Threading.cc
+++ b/source/Threading.cc
@@ -79,6 +79,7 @@ Threading::GetNumberOfPhysicalCpus()
     sysctlbyname("hw.physicalcpu", &count, &count_len, nullptr, 0);
     return static_cast<unsigned>(count);
 #elif defined(PTL_LINUX)
+    unsigned core_id_count = 0;
     std::ifstream ifs("/proc/cpuinfo");
     if(ifs)
     {
@@ -101,7 +102,9 @@ Threading::GetNumberOfPhysicalCpus()
                 core_ids.insert(line);
             }
         }
-        return static_cast<unsigned>(core_ids.size());
+        core_id_count = static_cast<unsigned>(core_ids.size());
+        if(core_id_count > 0)
+            return core_id_count;
     }
     return GetNumberOfCores();
 #else

--- a/source/Threading.cc
+++ b/source/Threading.cc
@@ -79,7 +79,7 @@ Threading::GetNumberOfPhysicalCpus()
     sysctlbyname("hw.physicalcpu", &count, &count_len, nullptr, 0);
     return static_cast<unsigned>(count);
 #elif defined(PTL_LINUX)
-    unsigned core_id_count = 0;
+    unsigned      core_id_count = 0;
     std::ifstream ifs("/proc/cpuinfo");
     if(ifs)
     {


### PR DESCRIPTION
On armhf this function could return 0, as /proc/cpuinfo does not contain any
"core id" lines:
```
# cat /proc/cpuinfo
processor	: 0
BogoMIPS	: 100.00
Features	: fp asimd evtstrm cpuid
CPU implementer	: 0x50
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0x000
CPU revision	: 1

```

This leads to a division-by-zero in the minimal.cc example. We should fall back
to GetNumberOfCores() if it would be 0.

Fixes: https://github.com/jrmadsen/PTL/issues/25