### PR TITLE
Minor fixes for macOS/Clang and use as a subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # -------------------------------------------------------------------------------------- #
 # cmake settings
 #
-cmake_minimum_required(VERSION 3.8...3.20)
+cmake_minimum_required(VERSION 3.8...3.23)
 if(${CMAKE_VERSION} VERSION_LESS 3.12)
     cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
 endif()

--- a/cmake/Modules/PTLBuildSettings.cmake
+++ b/cmake/Modules/PTLBuildSettings.cmake
@@ -129,7 +129,9 @@ if(PTL_USE_SANITIZER)
 endif()
 
 # Clang Tooling
-include(PTLFormatting)
+if(PTL_MASTER_PROJECT)
+    include(PTLFormatting)
+endif()
 
 ptl_add_option(PTL_USE_CLANG_TIDY "Enable running clang-tidy on sources" OFF)
 if(PTL_USE_CLANG_TIDY)

--- a/cmake/Modules/PTLPackageConfigHelpers.cmake
+++ b/cmake/Modules/PTLPackageConfigHelpers.cmake
@@ -51,12 +51,12 @@ configure_file(${PROJECT_SOURCE_DIR}/cmake/Templates/${PROJECT_NAME}BuildTargets
 # PTL pkg-config file install NB: The `-std=c++<EPOCH>` flag is currently exported to
 # Cflags. Not at all clear how this is supposed to be handled in pkg-config yet. This is
 # therefore a "simplest and dumbest" solution
-set(PTL_PC_INCLUDEDIR "\${prefix}/PTL_INSTALL_INCLUDEDIR}")
+set(PTL_PC_INCLUDEDIR "\${prefix}/${PTL_INSTALL_INCLUDEDIR}")
 if(IS_ABSOLUTE "${PTL_INSTALL_INCLUDEDIR}")
     set(PTL_PC_INCLUDEDIR "${PTL_INSTALL_INCLUDEDIR}")
 endif()
 
-set(PTL_PC_LIBDIR "\${prefix}/PTL_INSTALL_LIBDIR}")
+set(PTL_PC_LIBDIR "\${prefix}/${PTL_INSTALL_LIBDIR}")
 if(IS_ABSOLUTE "${PTL_INSTALL_LIBDIR}")
     set(PTL_PC_INCLUDEDIR "${PTL_INSTALL_LIBDIR}")
 endif()

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -56,6 +56,8 @@ if(BUILD_SHARED_LIBS)
         target_link_libraries(ptl-shared PUBLIC TBB::tbb)
     endif()
 
+    target_compile_definitions(ptl-shared PUBLIC PTL_BUILD_DLL)
+
     target_include_directories(
         ptl-shared
         PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/source>

--- a/source/PTL/Types.hh
+++ b/source/PTL/Types.hh
@@ -63,7 +63,7 @@
 // Define DLL export macro for WIN32 systems for
 // importing/exporting external symbols to DLLs
 //
-#    if defined LIB_BUILD_DLL
+#    if defined PTL_BUILD_DLL
 #        define DLLEXPORT __declspec(dllexport)
 #        define DLLIMPORT __declspec(dllimport)
 #    else

--- a/source/TaskRunManager.cc
+++ b/source/TaskRunManager.cc
@@ -152,7 +152,8 @@ void
 TaskRunManager::Terminate()
 {
     m_is_initialized = false;
-    m_thread_pool->destroy_threadpool();
+    if(m_thread_pool)
+        m_thread_pool->destroy_threadpool();
     delete m_task_manager;
     delete m_thread_pool;
     m_task_manager = nullptr;

--- a/source/ThreadPool.cc
+++ b/source/ThreadPool.cc
@@ -255,13 +255,13 @@ ThreadPool::Config::Config(bool _init, bool _use_tbb, bool _use_affinity, int _v
 ThreadPool::ThreadPool(const Config& _cfg)
 : m_use_affinity{ _cfg.use_affinity }
 , m_tbb_tp{ _cfg.use_tbb }
-, m_pool_state{ std::make_shared<std::atomic_short>(thread_pool::state::NONINIT) }
 , m_verbose{ _cfg.verbose }
 , m_priority{ _cfg.priority }
+, m_pool_state{ std::make_shared<std::atomic_short>(thread_pool::state::NONINIT) }
 , m_task_queue{ _cfg.task_queue }
-, m_affinity_func{ _cfg.set_affinity }
 , m_init_func{ _cfg.initializer }
 , m_fini_func{ _cfg.finalizer }
+, m_affinity_func{ _cfg.set_affinity }
 {
     auto master_id = get_this_thread_id();
     if(master_id != 0 && m_verbose > 1)

--- a/source/ThreadPool.cc
+++ b/source/ThreadPool.cc
@@ -673,7 +673,7 @@ ThreadPool::destroy_threadpool()
 
     auto _active = m_thread_active->load();
 
-    if(get_verbose() >= 0)
+    if(get_verbose() > 0)
     {
         if(_active == 0)
         {

--- a/source/Threading.cc
+++ b/source/Threading.cc
@@ -35,6 +35,10 @@
 #    include <unistd.h>
 #endif
 
+#if defined(PTL_MACOS)
+#    include <sys/sysctl.h>
+#endif
+
 #if defined(PTL_LINUX)
 #    include <fstream>
 #endif


### PR DESCRIPTION
Just a few small fixes found when using PTL in Geant4:

- Address compile issues on macOS/Clang with missing header and initialisation order
- Backport fix to `TaskRunManager::Terminate` checking for non-null thread pool before accessing it
- Silence output to `cerr` in `ThreadPool::destroy_threadpool` for zero verbosity
  - This caused test failures in Geant4 as CTest regards stderr output as a fail
- Only enable formatting for a master project, otherwise options are propagated to parent project
- Bump "maximum" CMake version to 3.23 (tested locally, no policy issues identified) 