### PR TITLE
Make copy explicit in range loop to suppress GCC 11 warnings

### DIFF
--- a/source/Threading.cc
+++ b/source/Threading.cc
@@ -96,7 +96,7 @@ Threading::GetNumberOfPhysicalCpus()
                 break;
             if(line.find("core id") != std::string::npos)
             {
-                for(std::string&& itr : { "core id", ":", " ", "\t" })
+                for(std::string itr : { "core id", ":", " ", "\t" })
                 {
                     static auto _npos = std::string::npos;
                     auto        _pos  = _npos;


### PR DESCRIPTION
GCC 11 can emit a range-loop-construct warning when binding to a temporary. As the loop is not performance critical and short strings always apply, make the copy explicit to suppress the warning.

Identified in Geant4 testing.