### PR TITLE
Set PTL_SANITIZER_TYPE to existing value, if it exists

### DIFF
--- a/cmake/Modules/PTLBuildSettings.cmake
+++ b/cmake/Modules/PTLBuildSettings.cmake
@@ -119,8 +119,13 @@ endif()
 # https://discourse.cmake.org/t/best-practice-for-multi-config-build-options/2049
 ptl_add_option(PTL_USE_SANITIZER "Enable -fsanitize=<type>" OFF)
 if(PTL_USE_SANITIZER)
+    set(__ptl_sanitizer_type_default "thread")
+    if(PTL_SANITIZER_TYPE)
+      set(__ptl_sanitizer_type_default "${PTL_SANITIZER_TYPE}")
+    endif()
+
     set(PTL_SANITIZER_TYPE
-        "thread"
+        "${__ptl_sanitizer_type_default}"
         CACHE STRING "Sanitizer type (-fsanitize=<type>)")
     set_property(CACHE PTL_SANITIZER_TYPE PROPERTY STRINGS "thread" "address" "undefined")
     ptl_message_on_change(PTL_SANITIZER_TYPE "Building PTL with sanitizer type")

--- a/cmake/Modules/PTLBuildSettings.cmake
+++ b/cmake/Modules/PTLBuildSettings.cmake
@@ -121,7 +121,7 @@ ptl_add_option(PTL_USE_SANITIZER "Enable -fsanitize=<type>" OFF)
 if(PTL_USE_SANITIZER)
     set(__ptl_sanitizer_type_default "thread")
     if(PTL_SANITIZER_TYPE)
-      set(__ptl_sanitizer_type_default "${PTL_SANITIZER_TYPE}")
+        set(__ptl_sanitizer_type_default "${PTL_SANITIZER_TYPE}")
     endif()
 
     set(PTL_SANITIZER_TYPE


### PR DESCRIPTION
Prior to CMake 3.21, CMake's set(... CACHE ...) command could override existing values of a variable:

- https://gitlab.kitware.com/cmake/cmake/-/issues/22038

This was fixed in 3.21 so that setting the cache value would not override any existing value:

https://gitlab.kitware.com/cmake/cmake/-/merge_requests/6146

If PTL is used as a subproject, any value for `PTL_SANITIZER_TYPE` set by the main project will be overriden to the default "thread". This can lead to build errors due to more than one, incompatible, sanitization options being used.

Set PTL_SANITIZER_TYPE to the existing value if it exists, avoiding override, otherwise defaulting to "thread". This yields the same behaviour for all CMake versions supported by PTL, up to there latest 3.23 release.