### PR TITLE
Address resource leakage, unneeded dereferences, noxcept issue identified by Geant4 Coverity checks 

### DIFF
--- a/source/PTL/TaskManager.hh
+++ b/source/PTL/TaskManager.hh
@@ -54,7 +54,7 @@ public:
 public:
     // Constructor and Destructors
     explicit TaskManager(ThreadPool*, bool _manage_pool = true);
-    virtual ~TaskManager();
+    virtual ~TaskManager() noexcept(false);
 
     TaskManager(const TaskManager&) = delete;
     TaskManager(TaskManager&&)      = default;
@@ -265,7 +265,7 @@ inline PTL::TaskManager::TaskManager(ThreadPool* _pool, bool _manage_pool)
 
 //--------------------------------------------------------------------------------------//
 
-inline PTL::TaskManager::~TaskManager()
+inline PTL::TaskManager::~TaskManager() noexcept(false)
 {
     finalize();
     if(fgInstance() == this)

--- a/source/PTL/ThreadPool.hh
+++ b/source/PTL/ThreadPool.hh
@@ -257,10 +257,7 @@ public:
     void notify_all();
     void notify(size_type);
     bool is_initialized() const;
-    int  get_active_threads_count() const
-    {
-        return m_thread_awake->load();
-    }
+    int  get_active_threads_count() const { return m_thread_awake->load(); }
 
     void set_affinity(affinity_func_t f) { m_affinity_func = std::move(f); }
     void set_affinity(intmax_t i, Thread&) const;

--- a/source/PTL/ThreadPool.hh
+++ b/source/PTL/ThreadPool.hh
@@ -259,7 +259,7 @@ public:
     bool is_initialized() const;
     int  get_active_threads_count() const
     {
-        return (m_thread_awake) ? m_thread_awake->load() : 0;
+        return m_thread_awake->load();
     }
 
     void set_affinity(affinity_func_t f) { m_affinity_func = std::move(f); }
@@ -303,8 +303,8 @@ private:
     ThreadId         m_main_tid          = ThisThread::get_id();
     atomic_bool_type m_alive_flag        = std::make_shared<std::atomic_bool>(false);
     pool_state_type  m_pool_state        = std::make_shared<std::atomic_short>(0);
-    atomic_int_type  m_thread_awake      = std::make_shared<std::atomic_uintmax_t>();
-    atomic_int_type  m_thread_active     = std::make_shared<std::atomic_uintmax_t>();
+    atomic_int_type  m_thread_awake      = std::make_shared<std::atomic_uintmax_t>(0);
+    atomic_int_type  m_thread_active     = std::make_shared<std::atomic_uintmax_t>(0);
 
     // locks
     lock_t m_task_lock = std::make_shared<Mutex>();
@@ -343,7 +343,7 @@ inline void
 ThreadPool::notify()
 {
     // wake up one thread that is waiting for a task to be available
-    if(m_thread_awake && m_thread_awake->load() < m_pool_size)
+    if(m_thread_awake->load() < m_pool_size)
     {
         AutoLock l(*m_task_lock);
         m_task_cond->notify_one();
@@ -365,7 +365,7 @@ ThreadPool::notify(size_type ntasks)
         return;
 
     // wake up as many threads that tasks just added
-    if(m_thread_awake && m_thread_awake->load() < m_pool_size)
+    if(m_thread_awake->load() < m_pool_size)
     {
         AutoLock l(*m_task_lock);
         if(ntasks < this->size())

--- a/source/ThreadPool.cc
+++ b/source/ThreadPool.cc
@@ -338,8 +338,7 @@ ThreadPool::is_initialized() const
 void
 ThreadPool::record_entry()
 {
-    if(m_thread_active)
-        ++(*m_thread_active);
+    ++(*m_thread_active);
 }
 
 //======================================================================================//
@@ -347,8 +346,7 @@ ThreadPool::record_entry()
 void
 ThreadPool::record_exit()
 {
-    if(m_thread_active)
-        --(*m_thread_active);
+    --(*m_thread_active);
 }
 
 //======================================================================================//
@@ -876,7 +874,7 @@ ThreadPool::execute_thread(VUserTaskQueue* _task_queue)
 
             if(_task_queue->true_size() == 0)
             {
-                if(m_thread_awake && m_thread_awake->load() > 0)
+                if(m_thread_awake->load() > 0)
                     --(*m_thread_awake);
 
                 // lock before sleeping on condition
@@ -896,7 +894,7 @@ ThreadPool::execute_thread(VUserTaskQueue* _task_queue)
                     _task_lock.unlock();
 
                 // notify that is awake
-                if(m_thread_awake && m_thread_awake->load() < m_pool_size)
+                if(m_thread_awake->load() < m_pool_size)
                     ++(*m_thread_awake);
             }
             else

--- a/source/ThreadPool.cc
+++ b/source/ThreadPool.cc
@@ -322,7 +322,7 @@ ThreadPool::~ThreadPool()
         delete m_task_queue;
 
     delete m_tbb_task_arena;
-    delete m_tbb_task_group; 
+    delete m_tbb_task_group;
 }
 
 //======================================================================================//

--- a/source/ThreadPool.cc
+++ b/source/ThreadPool.cc
@@ -316,6 +316,13 @@ ThreadPool::~ThreadPool()
             itr.join();
         m_threads.clear();
     }
+
+    // delete owned resources
+    if(m_delete_task_queue)
+        delete m_task_queue;
+
+    delete m_tbb_task_arena;
+    delete m_tbb_task_group; 
 }
 
 //======================================================================================//


### PR DESCRIPTION
The current round of Coverity static analysis identified a couple of minor issues in PTL, which this PR attempts to address:

- `ThreadPool` owns some resources via raw pointers, which should be `delete`d in its destructor in case the `destroy_threadpool` member function was _not_ called beforehand. This is safe as deleting a null pointer is fine.
- No need to check non-null on ThreadPool's `shared_ptr` resources as these always hold something.
- `TaskManager`s destructor needs to be marked `noexcept(false)` as it may throw due to the call to `ThreadPool::destroy_threadpool`.
  - If the potential exception can be handled in `TaskManager::finalize`, that would be the better solution, but it's not clear to me that this can done. 