### PR TITLE
Remove environment variables for ThreadPool configuration other than number of threads

### DIFF
--- a/source/PTL/TaskRunManager.hh
+++ b/source/PTL/TaskRunManager.hh
@@ -82,6 +82,7 @@ protected:
     // Barriers: synch points between master and workers
     bool            m_is_initialized = false;
     uint64_t        m_workers        = 0;
+    bool            m_use_tbb        = false;
     VUserTaskQueue* m_task_queue     = nullptr;
     ThreadPool*     m_thread_pool    = nullptr;
     TaskManager*    m_task_manager   = nullptr;

--- a/source/PTL/ThreadPool.hh
+++ b/source/PTL/ThreadPool.hh
@@ -140,7 +140,7 @@ public:
         bool              use_tbb      = f_use_tbb();
         bool              use_affinity = f_use_cpu_affinity();
         int               verbose      = 0;
-        int               priority     = f_thread_priority();
+        int               priority     = 0;
         size_type         pool_size    = f_default_pool_size();
         VUserTaskQueue*   task_queue   = nullptr;
         affinity_func_t   set_affinity = affinity_functor();
@@ -185,8 +185,6 @@ public:
     static void set_default_use_tbb(bool _v) { set_use_tbb(_v); }
     /// set the default use of cpu affinity
     static void set_default_use_cpu_affinity(bool _v);
-    /// set the default scheduling priority of threads in thread-pool
-    static void set_default_scheduling_priority(int _v) { f_thread_priority() = _v; }
     /// set the default pool size
     static void set_default_size(size_type _v) { f_default_pool_size() = _v; }
 
@@ -194,8 +192,6 @@ public:
     static bool get_default_use_tbb() { return f_use_tbb(); }
     /// get the default use of cpu affinity
     static bool get_default_use_cpu_affinity() { return f_use_cpu_affinity(); }
-    /// get the default scheduling priority of threads in thread-pool
-    static int get_default_scheduling_priority() { return f_thread_priority(); }
     /// get the default pool size
     static size_type get_default_size() { return f_default_pool_size(); }
 
@@ -277,7 +273,7 @@ private:
     bool             m_tbb_tp            = false;
     bool             m_delete_task_queue = false;
     int              m_verbose           = 0;
-    int              m_priority          = f_thread_priority();
+    int              m_priority          = 0;
     size_type        m_pool_size         = 0;
     ThreadId         m_main_tid          = ThisThread::get_id();
     atomic_bool_type m_alive_flag        = std::make_shared<std::atomic_bool>(false);
@@ -311,7 +307,6 @@ private:
 private:
     static bool&            f_use_tbb();
     static bool&            f_use_cpu_affinity();
-    static int&             f_thread_priority();
     static size_type&       f_default_pool_size();
     static thread_id_map_t& f_thread_ids();
 };

--- a/source/PTL/ThreadPool.hh
+++ b/source/PTL/ThreadPool.hh
@@ -138,7 +138,7 @@ public:
     {
         bool              init         = true;
         bool              use_tbb      = f_use_tbb();
-        bool              use_affinity = f_use_cpu_affinity();
+        bool              use_affinity = false;
         int               verbose      = 0;
         int               priority     = 0;
         size_type         pool_size    = f_default_pool_size();
@@ -183,15 +183,11 @@ public:
 
     /// set the default use of tbb
     static void set_default_use_tbb(bool _v) { set_use_tbb(_v); }
-    /// set the default use of cpu affinity
-    static void set_default_use_cpu_affinity(bool _v);
     /// set the default pool size
     static void set_default_size(size_type _v) { f_default_pool_size() = _v; }
 
     /// get the default use of tbb
     static bool get_default_use_tbb() { return f_use_tbb(); }
-    /// get the default use of cpu affinity
-    static bool get_default_use_cpu_affinity() { return f_use_cpu_affinity(); }
     /// get the default pool size
     static size_type get_default_size() { return f_default_pool_size(); }
 
@@ -306,7 +302,6 @@ private:
 
 private:
     static bool&            f_use_tbb();
-    static bool&            f_use_cpu_affinity();
     static size_type&       f_default_pool_size();
     static thread_id_map_t& f_thread_ids();
 };

--- a/source/PTL/ThreadPool.hh
+++ b/source/PTL/ThreadPool.hh
@@ -139,7 +139,7 @@ public:
         bool              init         = true;
         bool              use_tbb      = f_use_tbb();
         bool              use_affinity = f_use_cpu_affinity();
-        int               verbose      = f_verbose();
+        int               verbose      = 0;
         int               priority     = f_thread_priority();
         size_type         pool_size    = f_default_pool_size();
         VUserTaskQueue*   task_queue   = nullptr;
@@ -187,8 +187,6 @@ public:
     static void set_default_use_cpu_affinity(bool _v);
     /// set the default scheduling priority of threads in thread-pool
     static void set_default_scheduling_priority(int _v) { f_thread_priority() = _v; }
-    /// set the default verbosity
-    static void set_default_verbose(int _v) { f_verbose() = _v; }
     /// set the default pool size
     static void set_default_size(size_type _v) { f_default_pool_size() = _v; }
 
@@ -198,8 +196,6 @@ public:
     static bool get_default_use_cpu_affinity() { return f_use_cpu_affinity(); }
     /// get the default scheduling priority of threads in thread-pool
     static int get_default_scheduling_priority() { return f_thread_priority(); }
-    /// get the default verbosity
-    static int get_default_verbose() { return f_verbose(); }
     /// get the default pool size
     static size_type get_default_size() { return f_default_pool_size(); }
 
@@ -280,7 +276,7 @@ private:
     bool             m_use_affinity      = false;
     bool             m_tbb_tp            = false;
     bool             m_delete_task_queue = false;
-    int              m_verbose           = f_verbose();
+    int              m_verbose           = 0;
     int              m_priority          = f_thread_priority();
     size_type        m_pool_size         = 0;
     ThreadId         m_main_tid          = ThisThread::get_id();
@@ -316,7 +312,6 @@ private:
     static bool&            f_use_tbb();
     static bool&            f_use_cpu_affinity();
     static int&             f_thread_priority();
-    static int&             f_verbose();
     static size_type&       f_default_pool_size();
     static thread_id_map_t& f_thread_ids();
 };

--- a/source/PTL/ThreadPool.hh
+++ b/source/PTL/ThreadPool.hh
@@ -137,7 +137,7 @@ public:
     struct Config
     {
         bool              init         = true;
-        bool              use_tbb      = f_use_tbb();
+        bool              use_tbb      = false;
         bool              use_affinity = false;
         int               verbose      = 0;
         int               priority     = 0;
@@ -176,18 +176,9 @@ public:
     bool is_tbb_threadpool() const { return m_tbb_tp; }
 
 public:
-    // Public functions related to TBB
-    static bool using_tbb();
-    // enable using TBB if available - semi-deprecated
-    static void set_use_tbb(bool _v);
-
-    /// set the default use of tbb
-    static void set_default_use_tbb(bool _v) { set_use_tbb(_v); }
     /// set the default pool size
     static void set_default_size(size_type _v) { f_default_pool_size() = _v; }
 
-    /// get the default use of tbb
-    static bool get_default_use_tbb() { return f_use_tbb(); }
     /// get the default pool size
     static size_type get_default_size() { return f_default_pool_size(); }
 
@@ -301,7 +292,6 @@ private:
     affinity_func_t   m_affinity_func = affinity_functor();
 
 private:
-    static bool&            f_use_tbb();
     static size_type&       f_default_pool_size();
     static thread_id_map_t& f_thread_ids();
 };

--- a/source/TaskRunManager.cc
+++ b/source/TaskRunManager.cc
@@ -68,12 +68,10 @@ TaskRunManager::GetInstance(bool useTBB)
 
 TaskRunManager::TaskRunManager(bool useTBB)
 : m_workers(std::thread::hardware_concurrency())
+, m_use_tbb(useTBB)
 {
     if(!GetPrivateMasterRunManager())
         GetPrivateMasterRunManager() = this;
-
-    // handle TBB
-    ThreadPool::set_use_tbb(useTBB);
 }
 
 //======================================================================================//
@@ -97,6 +95,7 @@ TaskRunManager::Initialize(uint64_t n)
         ThreadPool::Config cfg;
         cfg.pool_size  = m_workers;
         cfg.task_queue = m_task_queue;
+        cfg.use_tbb    = m_use_tbb;
         m_thread_pool  = new ThreadPool(cfg);
         m_task_manager = new TaskManager(m_thread_pool);
     }

--- a/source/ThreadPool.cc
+++ b/source/ThreadPool.cc
@@ -663,9 +663,6 @@ ThreadPool::get_valid_queue(task_queue_t*& _queue) const
 void
 ThreadPool::execute_thread(VUserTaskQueue* _task_queue)
 {
-    // how long the thread waits on condition variable
-    // static int wait_time = GetEnv<int>("PTL_POOL_WAIT_TIME", 5);
-
     ++(*m_thread_awake);
 
     // initialization function

--- a/source/ThreadPool.cc
+++ b/source/ThreadPool.cc
@@ -84,15 +84,6 @@ ThreadPool::f_use_cpu_affinity()
 
 //======================================================================================//
 
-int&
-ThreadPool::f_thread_priority()
-{
-    static int _v = GetEnv<int>("PTL_THREAD_PRIORITY", 0);
-    return _v;
-}
-
-//======================================================================================//
-
 ThreadPool::size_type&
 ThreadPool::f_default_pool_size()
 {

--- a/source/ThreadPool.cc
+++ b/source/ThreadPool.cc
@@ -93,15 +93,6 @@ ThreadPool::f_thread_priority()
 
 //======================================================================================//
 
-int&
-ThreadPool::f_verbose()
-{
-    static int _v = GetEnv<int>("PTL_VERBOSE", 0);
-    return _v;
-}
-
-//======================================================================================//
-
 ThreadPool::size_type&
 ThreadPool::f_default_pool_size()
 {

--- a/source/ThreadPool.cc
+++ b/source/ThreadPool.cc
@@ -75,15 +75,6 @@ ThreadPool::f_use_tbb()
 
 //======================================================================================//
 
-bool&
-ThreadPool::f_use_cpu_affinity()
-{
-    static bool _v = GetEnv<bool>("PTL_CPU_AFFINITY", false);
-    return _v;
-}
-
-//======================================================================================//
-
 ThreadPool::size_type&
 ThreadPool::f_default_pool_size()
 {
@@ -143,18 +134,6 @@ ThreadPool::set_use_tbb(bool enable)
 {
 #if defined(PTL_USE_TBB)
     f_use_tbb() = enable;
-#else
-    ConsumeParameters(enable);
-#endif
-}
-
-//======================================================================================//
-// static member function that initialized tbb library
-void
-ThreadPool::set_default_use_cpu_affinity(bool enable)
-{
-#if defined(PTL_USE_TBB)
-    f_use_cpu_affinity() = enable;
 #else
     ConsumeParameters(enable);
 #endif

--- a/source/ThreadPool.cc
+++ b/source/ThreadPool.cc
@@ -66,15 +66,6 @@ ThreadPool::f_thread_ids()
 
 //======================================================================================//
 
-bool&
-ThreadPool::f_use_tbb()
-{
-    static bool _v = GetEnv<bool>("PTL_USE_TBB", false);
-    return _v;
-}
-
-//======================================================================================//
-
 ThreadPool::size_type&
 ThreadPool::f_default_pool_size()
 {
@@ -117,26 +108,6 @@ ThreadPool::start_thread(ThreadPool* tp, thread_data_t* _data, intmax_t _idx)
         std::cerr << "[PTL::ThreadPool] Thread " << _idx << " terminating..."
                   << std::endl;
     }
-}
-
-//======================================================================================//
-// static member function that checks enabling of tbb library
-bool
-ThreadPool::using_tbb()
-{
-    return f_use_tbb();
-}
-
-//======================================================================================//
-// static member function that initialized tbb library
-void
-ThreadPool::set_use_tbb(bool enable)
-{
-#if defined(PTL_USE_TBB)
-    f_use_tbb() = enable;
-#else
-    ConsumeParameters(enable);
-#endif
 }
 
 //======================================================================================//


### PR DESCRIPTION
The current `ThreadPool` implementation uses several environment variables for setting defaults. These are all configurable in code via the `ThreadPool::Config` object, and in fact the tests do this themselves, so I think it makes sense to only retain one of these for simplicity/clarity:

1. Use of TBB (`PTL_USE_TBB`)
   - Use of TBB by PTL is a build time option, so it doesn't really make sense to have this as a env var as it may well not be honoured anyway.
2. CPU affinity (`PTL_CPU_AFFINITY`), Thread priority (`PTL_THREAD_PRIORITY`)
   - These feel like rather advanced options and better left to decision in code (which could use env vars, but PTL shouldn't require it).
3. Logging verbosity (`PTL_VERBOSE`)
   - PTL is a library rather than an application, so it should really always default to "no output". Longer term it would be better to have an abstract logging interface so clients can implement this/forward messages to their own system (if it makes sense at all for PTL to log).
4. Pool size (`PTL_NUM_THREADS`)
   - This seems logical to keep for now in line with, e.g. OpenMP's `OMP_NUM_THREADS`.
 
The changes here therefore propose the removal of all of these except `PTL_NUM_THREADS`, with the defaults in `ThreadPool::Config` updated to those used in the removed `GetEnv` calls. All parameters are still configurable via the `ThreadPool::Config` object, as in done in the existing tests etc. Tests seem o.k. with these changes, but CI may throw something up, let's see.