### PR TITLE
Use CMake version range to support CMake 3.30 and newer

### DIFF
--- a/cmake/Templates/PTLConfig.cmake.in
+++ b/cmake/Templates/PTLConfig.cmake.in
@@ -3,7 +3,7 @@
 #
 @PACKAGE_INIT@
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.8...3.27)
 
 # -------------------------------------------------------------------------------------- #
 # basic paths


### PR DESCRIPTION
PTLConfig's use of a single version in `cmake_minimum_required` results in a warning:

```
CMake Deprecation Warning at build/source/externals/ptl/PTLConfig.cmake:30 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

Use ...<max> suffix to state compatibility with newer versions and resolve warning. CMake 3.27 chosen as this matches the max version tested in Geant4's CI across several platforms.