### PR TITLE
Use cmake policy instead of minimum

### DIFF
--- a/cmake/Templates/PTLConfig.cmake.in
+++ b/cmake/Templates/PTLConfig.cmake.in
@@ -1,13 +1,13 @@
 # -------------------------------------------------------------------------------------- #
 
 if("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" LESS 2.8)
-   message(FATAL_ERROR "CMake >= 3.0.0 required")
+   message(FATAL_ERROR "CMake >= 3.8.0 required")
 endif()
-if(CMAKE_VERSION VERSION_LESS "3.0.0")
-   message(FATAL_ERROR "CMake >= 3.0.0 required")
+if(CMAKE_VERSION VERSION_LESS "3.8.0")
+   message(FATAL_ERROR "CMake >= 3.8.0 required")
 endif()
 cmake_policy(PUSH)
-cmake_policy(VERSION 3.0.0...3.27)
+cmake_policy(VERSION 3.8.0...3.27)
 
 # package initialization
 #

--- a/cmake/Templates/PTLConfig.cmake.in
+++ b/cmake/Templates/PTLConfig.cmake.in
@@ -1,4 +1,3 @@
-# cmake/Templates/PTLConfig.cmake.in
 # -------------------------------------------------------------------------------------- #
 
 if("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" LESS 2.8)

--- a/cmake/Templates/PTLConfig.cmake.in
+++ b/cmake/Templates/PTLConfig.cmake.in
@@ -3,7 +3,8 @@
 #
 @PACKAGE_INIT@
 
-cmake_minimum_required(VERSION 3.8...3.27)
+cmake_policy(PUSH)
+cmake_policy(VERSION 3.0.0...3.27)
 
 # -------------------------------------------------------------------------------------- #
 # basic paths
@@ -78,3 +79,5 @@ if(NOT TARGET PTL::ptl)
         target_compile_definitions(PTL::ptl INTERFACE _PTL_ARCHIVE)
     endif()
 endif()
+
+cmake_policy(POP)

--- a/cmake/Templates/PTLConfig.cmake.in
+++ b/cmake/Templates/PTLConfig.cmake.in
@@ -1,10 +1,18 @@
+# cmake/Templates/PTLConfig.cmake.in
 # -------------------------------------------------------------------------------------- #
+
+if("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" LESS 2.8)
+   message(FATAL_ERROR "CMake >= 3.0.0 required")
+endif()
+if(CMAKE_VERSION VERSION_LESS "3.0.0")
+   message(FATAL_ERROR "CMake >= 3.0.0 required")
+endif()
+cmake_policy(PUSH)
+cmake_policy(VERSION 3.0.0...3.27)
+
 # package initialization
 #
 @PACKAGE_INIT@
-
-cmake_policy(PUSH)
-cmake_policy(VERSION 3.0.0...3.27)
 
 # -------------------------------------------------------------------------------------- #
 # basic paths


### PR DESCRIPTION
This is a follow-up to #51 and is related to some nasty obscure side effects of the policy alteration by the previous implementation, seen in https://github.com/celeritas-project/celeritas/pull/1573.

It's unusual to use `cmake_minimum_required` in a package config file, since it can alter policy scope elsewhere (depending, of course, on the policy that's been set). The `cmake_policy` command correctly scopes the changes to the Config file, rather than applying the change to the rest of the user's code when called from inside `find_package` or `find_dependency`.

The updated usage mirrors the CMake-generated `Targets.cmake` file: assertions to check for the rough CMake version, then a scoped policy change for the file itself.